### PR TITLE
Activation checkpointing option for UNets

### DIFF
--- a/imagen_pytorch/configs.py
+++ b/imagen_pytorch/configs.py
@@ -61,6 +61,7 @@ class Unet3DConfig(AllowExtraBaseModel):
     channels:           int = 3
     attn_dim_head:      int = 32
     attn_heads:         int = 16
+    use_checkpoint:     bool = False
 
     def create(self):
         return Unet3D(**self.dict())


### PR DESCRIPTION
Adds support for activation checkpointing to the UNet architecture and threads a flag out to the config to enable it on a per-UNet basis

TODO: send PR to upstream