### PR TITLE
Hack to make FP16 work again

### DIFF
--- a/imagen_pytorch/trainer.py
+++ b/imagen_pytorch/trainer.py
@@ -293,7 +293,8 @@ class ImagenTrainer(nn.Module):
 
         # cast data to fp16 at training time if needed
 
-        self.cast_half_at_training = accelerator_mixed_precision == 'fp16'
+        # self.cast_half_at_training = accelerator_mixed_precision == 'fp16'
+        self.cast_half_at_training = False
 
         # grad scaler must be managed outside of accelerator
 


### PR DESCRIPTION
`Imagen` asserts that inputs are of dtype float: 

https://github.com/lucidrains/imagen-pytorch/blob/726c11ad94c5ae8822f52aaea2bb2f30014d1241/imagen_pytorch/imagen_pytorch.py#L2635

However, when `'fp16': true` is in the config, the trainer casts input tensors to `fp16`:

https://github.com/lucidrains/imagen-pytorch/blob/726c11ad94c5ae8822f52aaea2bb2f30014d1241/imagen_pytorch/trainer.py#L131

Causing the `Imagen` class assert to fail. Not 100% sure what the intended behavior is here, so speculatively proposing to disable casting inputs to fp16

TODO: PR upstream